### PR TITLE
Add jinja filter to change heading indent

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,15 @@ We add `first_pass_output` to the rendering context, which is useful when you ne
 - `first_pass_output.source` contains the complete output of a first pass generation of the document.
 - `first_pass_output.lines` contains the same output as list of lines.
 
+### Jinja Filters
+
+The markdown files support three jinja filters within documents:
+
+ - invert_dependencies: Given a set of ids and dependency ids for an object, the two sets are switched making the original ids the dependent ids.
+ - join_to: Given a set of ids for an object, and a list of the objects these ids refer to, select out the objects by joining using the specified primary key (which defaults to 'id').
+ - md_indent: Processes a snippet of text and removes or adds header indents to match the indent pattern of surrounding text.
+
+
 ### Extensions
 
 We also support [extensions](http://jinja.pocoo.org/docs/2.10/extensions/). Extensions are set using the `md_extensions` configuration paramater in `config.yml`. See the Markdown Extensions section for details about available markdown extensions.

--- a/rdm/render.py
+++ b/rdm/render.py
@@ -34,6 +34,34 @@ def join_to(foreign_keys, table, primary_key='id'):
     return joined
 
 
+def md_indent(snippet, header_shift = 0):
+    lines = snippet.split('\n')
+    i = 0
+    in_code = False
+    if header_shift < 0:
+        while i > header_shift:
+            i -= 1
+            for j in range(0, len(lines)):
+                if lines[j][0:3] == "```":
+                    in_code = not in_code
+                if in_code:
+                    continue
+                if lines[j][0] == '#':
+                    lines[j] = lines[j][1:].lstrip()
+    else:
+        while i < header_shift:
+            i += 1
+            for j in range(0, len(lines)):
+                if lines[j][0:3] == "```":
+                    in_code = not in_code
+                if in_code:
+                    continue
+                if lines[j][0] == '#':
+                    lines[j] = '#'+ lines[j]
+    processed_snippet = "\n".join(lines)
+    return processed_snippet
+
+
 def render_template_to_file(config, template_filename, context, output_file, loaders=None):
     generator = generate_template_output(config, template_filename, context, loaders=loaders)
     TemplateStream(generator).dump(output_file)
@@ -74,6 +102,7 @@ def _create_jinja_environment(config, loaders=None):
     )
     environment.filters['invert_dependencies'] = invert_dependencies
     environment.filters['join_to'] = join_to
+    environment.filters['md_indent']= md_indent
     return environment
 
 

--- a/tests/md_indent_test.py
+++ b/tests/md_indent_test.py
@@ -1,3 +1,6 @@
+from rdm.render import md_indent
+
+
 def test_md_indent_basic():
     input_markdown= "\n".join(["Line 1", "# Line 2", "## Line 3"])
     expected_output_markdown= "\n".join(["Line 1", "Line 2", "# Line 3"])

--- a/tests/md_indent_test.py
+++ b/tests/md_indent_test.py
@@ -1,0 +1,28 @@
+def test_md_indent_basic():
+    input_markdown= "\n".join(["Line 1", "# Line 2", "## Line 3"])
+    expected_output_markdown= "\n".join(["Line 1", "Line 2", "# Line 3"])
+    assert md_indent(input_markdown,-1) == expected_output_markdown
+
+
+def test_md_indent_extra_trim():
+    input_markdown= "\n".join(["Line 1", "# Line 2", "## Line 3", "### Line 4"])
+    expected_output_markdown= "\n".join(["Line 1", "Line 2", "Line 3", "# Line 4"])
+    assert md_indent(input_markdown,-2) == expected_output_markdown
+
+
+def test_md_indent_codeblock():
+    input_markdown = "\n".join(["## Hello", "```","## Hello","```"])
+    expected_output_markdown= "\n".join(["# Hello", "```", "## Hello","```"])
+    assert md_indent(input_markdown, -1) == expected_output_markdown
+
+
+def test_md_indent_basic_add():
+    input_markdown= "\n".join(["Line 1", "# Line 2", "## Line 3"])
+    expected_output_markdown= "\n".join(["Line 1", "## Line 2", "### Line 3"])
+    assert md_indent(input_markdown,1) == expected_output_markdown
+
+
+def test_md_indent_add_codeblock():
+    input_markdown = "\n".join(["## Hello", "```","## Hello","```"])
+    expected_output_markdown= "\n".join(["### Hello", "```", "## Hello","```"])
+    assert md_indent(input_markdown, 1) == expected_output_markdown


### PR DESCRIPTION
Add a jinja filter to strip away heading indent levels or add
additional heading levels of snippets to match indent levels of
surrounding text. Also updated README to detail other jinja
filters available in rdm.