### PR TITLE
Add support for comments in summarized requirements text files

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ This script lets you write software requirements in a simpler format that looks 
 2 Loading
 2.1 Second requirement goes here.
 
+# Comments start with a "#" and are ignored by the converter
 3 Users
 3.1 Third requirement goes here.
 3.2 Fourth requirement goes here.

--- a/contrib/convert_requirements.py
+++ b/contrib/convert_requirements.py
@@ -41,6 +41,9 @@ def parse_requirements(fileobj):
     elements = collections.OrderedDict()
     parents = set()  # Set of keys known to appear above another key
     for line in lines:
+        # Skip comments
+        if line.strip().startswith("#"):
+            continue
         key_str, text = line.split(None, 1)
         key = DottedDecimal.from_text(key_str)
         if key.parent:


### PR DESCRIPTION
This is a very small tweak, but I found that when iterating on requirements at an early stage, it was helpful to leave comments in the text file indicating further TODOs or questions. This update to the `convert_requirements.py` script just skips lines beginning with `#` in order to support generating a requirements file even before all the comments have been resolved. For instance:

```
1. Serial Interface
1.1 The system shall communicate via a serial connection
# TODO add more details on baud rate, etc
1.2 The system shall support multiple serial interfaces
...
```