### PR TITLE
Add 2018 FDA cybersecurity checklist and associated documents

### DIFF
--- a/rdm/checklists/FDA-CYBER.txt
+++ b/rdm/checklists/FDA-CYBER.txt
@@ -1,0 +1,99 @@
+# Audit checklist for the FDA's various cybersecurity guidance
+#
+# The checklist covers the 2018 Draft Guidance, "Content of Premarket
+# Submissions for Management of Cybersecurity in Medical Devices".
+#
+# This checklist is not a substitute for reading, understanding, and implementing the associated standard.
+# The descriptive phrase following each keyword reference is intended only as a helpful mnemonic for locating
+# and recalling the referenced section of the standard.
+
+FDA-CYBER:IV.1 Indicate and justify the cybersecurity risk tier
+
+# Limit Access to Trusted Users & Devices Only
+FDA-CYBER:V.A.1.a.i Limit access to devices through the authentication of users
+FDA-CYBER:V.A.1.a.ii Use automatic timed methods to terminate sessions within the system where appropriate for the use environment.
+FDA-CYBER:V.A.1.a.iii Employ a layered authorization model by differentiating privileges based on the user role or device functions.
+FDA-CYBER:V.A.1.a.iv Use appropriate authentication (e.g., multi-factor authentication to permit privileged device access to system administrators, service technicians, maintenance personnel).
+FDA-CYBER:V.A.1.a.v Strengthen password protection. Do not use credentials that are hardcoded, default, easily guessed, easily compromised. Limit public access to passwords used for privileged device access.
+FDA-CYBER:V.A.1.a.vi Consider physical locks on devices and their communication ports to minimize tampering.
+
+# Authenticate and Check Authorization of Safety-Critical Commands
+FDA-CYBER:V.A.1.b.i Use authentication to prevent unauthorized access to device functions and to prevent unauthorized (arbitrary) software execution.
+FDA-CYBER:V.A.1.b.ii Require user authentication before permitting software or firmware updates, including those affecting the operating system, applications, and anti-malware.
+FDA-CYBER:V.A.1.b.ii Use cryptographically strong authentication resident on the device to authenticate personnel, messages, commands and as applicable, all other communication pathways.
+FDA-CYBER:V.A.1.b.iv Authenticate all external connections. For example, if a device connects to an offsite server, then it and the server should mutually authenticate, even if the connection is initiated over one or more existing trusted channels.
+FDA-CYBER:V.A.1.b.v Authenticate firmware and software. Verify signatures of software/firmware content, version numbers, and other metadata. The version numbers intended to be installed should themselves be signed/have MACs. Devices should be electronically identifiable (e.g., model number, serial number) to authorized users.
+FDA-CYBER:V.A.1.b.vi Perform authorization checks based on authentication credentials or other irrefutable evidence. For example, a medical device programmer should have elevated privileges that are granted based on cryptographic authentication or a signal of intent that cannot physically be produced by another device, e.g., a home monitor, with a software-based attack.
+FDA-CYBER:V.A.1.b.vii Devices should be designed to “deny by default,” i.e., that which is not expressly permitted by a device is denied by default. For example, the device should generally reject all unauthorized TCP, USB, Bluetooth, serial connections.
+FDA-CYBER:V.A.1.b.viii The principle of least privilege should be applied to allow only the level of access necessary to perform a function.
+
+# Code Integrity
+FDA-CYBER:V.A.2.a.i Only allow installation of cryptographically verified firmware/software updates. Ensure that a new update is more recent than the currently installed version to prevent downgrade attacks.
+FDA-CYBER:V.A.2.a.ii Where feasible, ensure that the integrity of software is validated prior to execution, e.g., 'whitelisting' based on digital signatures.
+
+# Data Integrity
+FDA-CYBER:V.A.2.b.i Verify the integrity of all incoming data (ensuring it is not modified in transit or at rest, and it is well-formed/compliant with the expected protocol/specification).
+FDA-CYBER:V.A.2.b.ii Ensure capability of secure data transfer to and from the device, and when appropriate, use methods for encryption and authentication of the end points with which data is being transferred.
+FDA-CYBER:V.A.2.b.iii Protect the integrity of data necessary to ensure the safety and essential performance of the device.
+FDA-CYBER:V.A.2.b.iv Use current NIST recommended standards for cryptography (e.g., FIPS 140-2, NIST26 Suite B27), or equivalent-strength cryptographic protection for communications channels.
+FDA-CYBER:V.A.2.b.v Use unique per device cryptographically secure communication keys to prevent leveraging the knowledge of one key to access a multitude of devices.
+
+# Execution Integrity
+FDA-CYBER:V.A.2.c.i Where feasible, use industry-accepted best practices to maintain/verify integrity of code while it is being executed on the device.
+
+# Maintain Confidentiality of Data
+FDA-CYBER:V.A.3 Manufacturers should ensure the confidentiality of any/all data whose disclosure could lead to patient harm (e.g., through use of credentials, encryption). Loss of confidentiality of credentials could be used by a threat to effect multi-patient harm. Lack of encryption to protect sensitive information "at rest" and “in transit” can expose this information to misuse that can lead to patient harm. Other harms, such as loss of confidential protected health information (PHI), are not considered “patient harms” for the purposes of this guidance.
+
+# Design the Device to Detect cybersecurity Events in a Timely Fashion
+FDA-CYBER:V.B.1.a Implement design features that allow for security compromises to be detected, recognized, logged, timed, and acted upon during normal use.
+FDA-CYBER:V.B.1.b Devices should be designed to permit routine security and antivirus scanning such that the safety and essential performance of the device is not impacted.
+FDA-CYBER:V.B.1.c Ensure the design enables forensic evidence capture. The design should include mechanisms to create and store log files for security events. Documentation should include how and where the log file is located, stored, recycled, archived, and how it could be consumed by automated analysis software (e.g. Intrusion Detection System, IDS). Examples of security events include but are not limited to configuration changes, network anomalies, login attempts, and anomalous traffic (e.g., sending requests to unknown entities).
+FDA-CYBER:V.B.1.d The device design should limit the potential impact of vulnerabilities by specifying a secure configuration. Secure configurations may include endpoint protections such as anti-malware, firewall/firewall rules, whitelisting, defining security event parameters, logging parameters, physical security detection.
+FDA-CYBER:V.B.1.e The device design should enable software configuration management and permit tracking and control of software changes to be electronically obtainable (i.e., machine readable) by authorized users.
+FDA-CYBER:V.B.1.f The product life-cycle, including its design, should facilitate a variant analysis of a vulnerability across device models and product lines.
+FDA-CYBER:V.B.1.g The device design should provide a CBOM in a machine readable, electronic format to be consumed automatically.
+
+# Design the Device to Respond to and Contain the Impact of a Potential Cybersecurity Incident
+FDA-CYBER:V.B.2.a The device should be designed to notify users upon detection of a potential cybersecurity breach.
+FDA-CYBER:V.B.2.b The device should be designed to anticipate the need for software patches and updates to address future cybersecurity vulnerabilities.
+FDA-CYBER:V.B.2.c The device should be designed to facilitate the rapid verification, validation, and testing of patches and updates.
+FDA-CYBER:V.B.2.d The design architecture should facilitate the rapid deployment of patches and updates.
+
+# Design the Device to Recover Capabilities or Services that were Impaired Due to a Cybersecurity Incident
+FDA-CYBER:V.B.3.b Implement device features that protect critical functionality and data, even when the device’s cybersecurity has been compromised.
+FDA-CYBER:V.B.3.c The design should provide methods for retention and recovery of device configuration by an authenticated privileged user.
+FDA-CYBER:V.B.3.d The design should specify the level of autonomous functionality (resilience) any component of the system possesses when its communication capabilities with the rest of the system are disrupted including disruption of significant duration.
+FDA-CYBER:V.B.3.e Devices should be designed to be resilient to possible cybersecurity incident scenarios such as network outages, Denial of Service attacks, excessive bandwidth usage by other products, disrupted quality of service (QoS), and excessive jitter (i.e., a variation in the delay of received packets).
+
+# NOTE: Labeling requirements aren't split out into smaller checklist items
+# because these are usually handled elsewhere. This checklist item is kept only
+# to help ensure checklist users are aware of the labeling requirements
+FDA-CYBER:VI Labeling recommendations for devices with cybersecurity risks
+
+# Design Documentation
+# NOTE: 7.A.1 and 7.A.2 are implicitly met via the section 5 checklist items
+FDA-CYBER:7.A.3 System diagrams that are sufficiently detailed to understand how cybersecurity risk controls are incorporated into the whole system
+FDA-CYBER:7.A.3.a Network, architecture, flow, and state diagrams.
+FDA-CYBER:7.A.3.b The interfaces, components, assets, communication pathways, protocols, and network ports.
+FDA-CYBER:7.A.3.c Authentication mechanisms and controls for each communicating asset or component of the system including web sites, servers, interoperable systems, cloud stores, etc.
+FDA-CYBER:7.A.3.d Users’ roles and level of responsibility if they interact with these assets or communication channels.
+FDA-CYBER:7.A.3.e Use of cryptographic methods should include descriptions of the method used and the type and level of cryptographic key usage and their style of use throughout your system (one-time use, key length, the standard employed, symmetric or otherwise, etc.). Descriptions should also include details of cryptographic protection for firmware and software updates.
+FDA-CYBER:7.A.4 A summary describing the design features that permit validated software updates and patches as needed throughout the life cycle of the medical device to continue to ensure its safety and effectiveness.
+
+# Risk Management Documentation
+FDA-CYBER:7.B.1 A system level threat model that includes a consideration of system level risks, including but not limited to risks related to the supply chain (e.g., to ensure the device remains free of malware), design, production, and deployment (i.e., into a connected/networked environment).
+FDA-CYBER:7.B.2 A specific list of all cybersecurity risks that were considered in the design of your device. The FDA recommends providing descriptions of risk that leverage an analysis of exploitablity to describe likelihood instead of probability. If numerical probabilities are provided, we recommend providing additional information that explains how the probability was calculated.
+FDA-CYBER:7.B.3 A specific list and justification for all cybersecurity controls that were established for your device. This should include all risk mitigations and design considerations pertaining to intentional and unintentional cybersecurity risks associated with your device.
+FDA-CYBER:7.B.3.a A list of verifiable function/subsystem requirements related to access control, encryption/decryption, firewalls, intrusion detection/prevention, antivirus packages, etc.
+FDA-CYBER:7.B.3.b A list of verifiable of security requirements impacting other functionality, data, and interface requirements.
+FDA-CYBER:7.B.4 A description of the testing that was done to ensure the adequacy of cybersecurity risk controls (e.g., security effectiveness in enforcing the specified security policy, performance for required traffic conditions, stability and reliability as appropriate). Test reports should include:
+FDA-CYBER:7.B.4.a testing of device performance
+FDA-CYBER:7.B.4.b evidence of security effectiveness of third-party OTS software in the system
+FDA-CYBER:7.B.4.c static and dynamic code analysis including testing for credentials that are “hardcoded”, default, easily-guessed, and easily compromised
+FDA-CYBER:7.B.4.d vulnerability scanning
+FDA-CYBER:7.B.4.e robustness testing
+FDA-CYBER:7.B.4.f boundary analysis
+FDA-CYBER:7.B.4.g penetration testing
+FDA-CYBER:7.B.4.h Third Party test reports
+FDA-CYBER:7.B.5 A traceability matrix that links your actual cybersecurity controls to the cybersecurity risks that were considered in your security risk and hazard analysis.
+FDA-CYBER:7.B.6 A CBOM cross referenced with the National Vulnerability Database (NVD) or similar known vulnerability database. Provide criteria for addressing known vulnerabilities and a rationale for not addressing remaining known vulnerabilities, consistent with the FDA’s final guidance, Postmarket Management of Cybersecurity in Medical Devices.

--- a/rdm/checklists/FDA-CYBER_2018.txt
+++ b/rdm/checklists/FDA-CYBER_2018.txt
@@ -65,10 +65,21 @@ FDA-CYBER:V.B.3.c The design should provide methods for retention and recovery o
 FDA-CYBER:V.B.3.d The design should specify the level of autonomous functionality (resilience) any component of the system possesses when its communication capabilities with the rest of the system are disrupted including disruption of significant duration.
 FDA-CYBER:V.B.3.e Devices should be designed to be resilient to possible cybersecurity incident scenarios such as network outages, Denial of Service attacks, excessive bandwidth usage by other products, disrupted quality of service (QoS), and excessive jitter (i.e., a variation in the delay of received packets).
 
-# NOTE: Labeling requirements aren't split out into smaller checklist items
-# because these are usually handled elsewhere. This checklist item is kept only
-# to help ensure checklist users are aware of the labeling requirements
-FDA-CYBER:VI Labeling recommendations for devices with cybersecurity risks
+# Labeling
+FDA-CYBER:VI.1 Device instructions and product specifications related to recommended cybersecurity controls appropriate for the intended use environment (e.g., anti-virus software, use of a firewall).
+FDA-CYBER:VI.2 A description of the device features that protect critical functionality, even when the device’s cybersecurity has been compromised.
+FDA-CYBER:VI.3 A description of backup and restore features and procedures to regain configurations.
+FDA-CYBER:VI.4 Specific guidance to users regarding supporting infrastructure requirements so that the device can operate as intended.
+FDA-CYBER:VI.5 A description of how the device is or can be hardened using secure configuration. Secure configurations may include end point protections such as anti-malware, firewall/firewall rules, whitelisting, security event parameters, logging parameters, physical security detection.
+FDA-CYBER:VI.6 A list of network ports and other interfaces that are expected to receive and/or send data, and a description of port functionality and whether the ports are incoming or outgoing (note that unused ports should be disabled).
+FDA-CYBER:VI.7 A description of systematic procedures for authorized users to download version-identifiable software and firmware from the manufacturer.
+FDA-CYBER:VI.8 A description of how the design enables the device to announce when anomalous conditions are detected (i.e., security events). Security event types could be configuration changes, network anomalies, login attempts, anomalous traffic (e.g., send requests to unknown entities).
+FDA-CYBER:VI.9 A description of how forensic evidence is captured, including but not limited to any log files kept for a security event. Log files descriptions should include how and where the log file is located, stored, recycled, archived, and how it could be consumed by automated analysis software (e.g., Intrusion Detection System, IDS).
+FDA-CYBER:VI.10 A description of the methods for retention and recovery of device configuration by an authenticated privileged user.
+FDA-CYBER:VI.11 Sufficiently detailed system diagrams for end-users.
+FDA-CYBER:VI.12 A CBOM including but not limited to a list of commercial, open source, and off-the-shelf software and hardware components to enable device users to effectively manage their assets, to understand the potential impact of identified vulnerabilities to the device (and the connected system), and to deploy countermeasures to maintain the device’s essential performance.
+FDA-CYBER:VI.13 Where appropriate, technical instructions to permit secure network (connected) deployment and servicing, and instructions for users on how to respond upon detection of a cybersecurity vulnerability or incident.
+FDA-CYBER:VI.14 Information, if known, concerning device cybersecurity end of support. At the end of support, a manufacturer may no longer be able to reasonably provide security patches or software updates. If the device remains in service following the end of support, the cybersecurity risks for end-users can be expected to increase over time.
 
 # Design Documentation
 # NOTE: 7.A.1 and 7.A.2 are implicitly met via the section 5 checklist items

--- a/rdm/init_files/documents/cyber_security.md
+++ b/rdm/init_files/documents/cyber_security.md
@@ -6,7 +6,7 @@ title: Cybersecurity Risk Management Report
 
 # Purpose
 
-The purpose of this document is to demonstrate the cybersecurity design controls and risk management found in {{device.name}}.
+The purpose of this document is to demonstrate the cybersecurity design controls and risk management found in {{device.name}} for FDA reviewers in a format that closely follows the 2018 Draft Guidance, "Content of Premarket Submissions for Management of Cybersecurity in Medical Devices".
 
 # Scope
 

--- a/rdm/init_files/documents/cyber_security.md
+++ b/rdm/init_files/documents/cyber_security.md
@@ -1,7 +1,368 @@
 ---
 id: CYBSEC-001
 revision: 1
-title: Cyber Security Analysis
+title: Cybersecurity Risk Management Report
 ---
 
-TODO: Fill in details here
+# Purpose
+
+The purpose of this document is to demonstrate the cybersecurity design controls and risk management found in {{device.name}}.
+
+# Scope
+
+This document applies to {{device.name}} release {{device.version}}.
+
+# Cybersecurity Risk Tier
+
+TODO: Select the appropriate cybersecurity risk tier, based on your device. Three possible wordings are provided for your convenience below. Include additional justification for your selection as appropriate.
+
+---
+
+{{device.name}} is Tier 1, "Higher Cybersecurity Risk," because
+
+1. The device is capable of connecting to another medical or non-medical product, to a network, or to the Internet, and
+2. A cybersecurity incident affecting the device could directly result in patient harm to multiple patients.
+
+---
+
+{{device.name}} is Tier 2, "Normal Cybersecurity Risk," because the device is _not_ capable of connecting to another medical or non-medical product, to a network, or to the Internet.
+
+---
+
+{{device.name}} is Tier 2, "Normal Cybersecurity Risk," because although the device is capable of connecting to another medical or non-medical product, to a network, or to the Internet, it a cybersecurity incident affecting the device could directly result in patient harm to multiple patients.
+
+---
+
+ENDTODO
+
+[[FDA-CYBER:4.1]]
+
+# System Diagrams
+
+TODO: Add System Diagrams that are sufficiently detailed to permit an understanding of how the specific device design elements are incorporated into a system-level and holistic picture. Analysis of the entire system is necessary to understand the manufacturer’s threat model and the device within the larger ecosystem. System diagrams should include:
+
+- Network, architecture, flow, and state diagrams.
+- The interfaces, components, assets, communication pathways, protocols, and network ports.
+- Authentication mechanisms and controls for each communicating asset or component of the system including web sites, servers, interoperable systems, cloud stores, etc.
+- Users’ roles and level of responsibility if they interact with these assets or communication channels.
+- Use of cryptographic methods should include descriptions of the method used and the type and level of cryptographic key usage and their style of use throughout your system (one-time use, key length, the standard employed, symmetric or otherwise, etc.). Descriptions should also include details of cryptographic protection for firmware and software updates.
+
+If you have diagrams like these in other documents, such as your software design specification, then includes links to the 
+
+ENDTODO
+
+[[These system diagrams fulfill FDA-CYBER:7.A.3, FDA-CYBER:7.A.3.a, FDA-CYBER:7.A.3.b, FDA-CYBER:7.A.3.c, FDA-CYBER:7.A.3.d, and FDA-CYBER:7.A.3.e]]
+
+# Software Updates and Patches
+
+TODO: Write a summary describing the design features that permit validated software updates and patches as needed throughout the life cycle of the medical device to continue to ensure its safety and effectiveness.
+
+[[FDA-CYBER:7.A.4]]
+
+# Cybersecurity Design Controls
+
+TODO: Tier 1 devices should demonstrate how all design controls listed below are implemented. To do this, we recommend listing the associated requirements. Tier 2 devices may provide a risk-based rationale for why specific design controls are not appropriate.
+
+This section enumerates all of the design controls recommended by the FDA for easy review by an FDA auditor.
+
+## Limit Access to Trusted Users & Devices Only
+
+*Limit access to devices through the authentication of users.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.A.1.a.i]]
+
+
+*Use automatic timed methods to terminate sessions within the system where appropriate for the use environment.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.A.1.a.ii]]
+
+
+*Employ a layered authorization model by differentiating privileges based on the user role or device functions.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.A.1.a.iii]]
+
+
+*Use appropriate authentication (e.g., multi-factor authentication to permit privileged device access to system administrators, service technicians, maintenance personnel).*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.A.1.a.iv]]
+
+
+*Strengthen password protection. Do not use credentials that are hardcoded, default, easily guessed, easily compromised. Limit public access to passwords used for privileged device access.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.A.1.a.v]]
+
+
+*Consider physical locks on devices and their communication ports to minimize tampering.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.A.1.a.vi]]
+
+# Authenticate and Check Authorization of Safety-Critical Commands
+
+
+*Use authentication to prevent unauthorized access to device functions and to prevent unauthorized (arbitrary) software execution.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.A.1.b.i]]
+
+
+*Require user authentication before permitting software or firmware updates, including those affecting the operating system, applications, and anti-malware.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.A.1.b.ii]]
+
+
+*Use cryptographically strong authentication resident on the device to authenticate personnel, messages, commands and as applicable, all other communication pathways.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.A.1.b.ii]]
+
+
+*Authenticate all external connections. For example, if a device connects to an offsite server, then it and the server should mutually authenticate, even if the connection is initiated over one or more existing trusted channels.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.A.1.b.iv]]
+
+
+*Authenticate firmware and software. Verify signatures of software/firmware content, version numbers, and other metadata. The version numbers intended to be installed should themselves be signed/have MACs. Devices should be electronically identifiable (e.g., model number, serial number) to authorized users.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.A.1.b.v]]
+
+
+*Perform authorization checks based on authentication credentials or other irrefutable evidence. For example, a medical device programmer should have elevated privileges that are granted based on cryptographic authentication or a signal of intent that cannot physically be produced by another device, e.g., a home monitor, with a software-based attack.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.A.1.b.vi]]
+
+
+*Devices should be designed to “deny by default,” i.e., that which is not expressly permitted by a device is denied by default. For example, the device should generally reject all unauthorized TCP, USB, Bluetooth, serial connections.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.A.1.b.vii]]
+
+
+*The principle of least privilege should be applied to allow only the level of access necessary to perform a function.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.A.1.b.viii]]
+
+
+## Code Integrity
+
+
+*Only allow installation of cryptographically verified firmware/software updates. Ensure that a new update is more recent than the currently installed version to prevent downgrade attacks.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.A.2.a.i]]
+
+
+*Where feasible, ensure that the integrity of software is validated prior to execution, e.g., 'whitelisting' based on digital signatures.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.A.2.a.ii]]
+
+
+## Data Integrity
+
+
+*Verify the integrity of all incoming data (ensuring it is not modified in transit or at rest, and it is well-formed/compliant with the expected protocol/specification).*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.A.2.b.i]]
+
+
+*Ensure capability of secure data transfer to and from the device, and when appropriate, use methods for encryption and authentication of the end points with which data is being transferred.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.A.2.b.ii]]
+
+
+*Protect the integrity of data necessary to ensure the safety and essential performance of the device.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.A.2.b.iii]]
+
+
+*Use current NIST recommended standards for cryptography (e.g., FIPS 140-2, NIST26 Suite B27), or equivalent-strength cryptographic protection for communications channels.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.A.2.b.iv]]
+
+
+*Use unique per device cryptographically secure communication keys to prevent leveraging the knowledge of one key to access a multitude of devices.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.A.2.b.v]]
+
+
+## Execution Integrity
+
+*Where feasible, use industry-accepted best practices to maintain/verify integrity of code while it is being executed on the device.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.A.2.c.i]]
+
+
+## Maintain Confidentiality of Data
+
+*Manufacturers should ensure the confidentiality of any/all data whose disclosure could lead to patient harm (e.g., through use of credentials, encryption). Loss of confidentiality of credentials could be used by a threat to effect multi-patient harm. Lack of encryption to protect sensitive information "at rest" and “in transit” can expose this information to misuse that can lead to patient harm. Other harms, such as loss of confidential protected health information (PHI), are not considered “patient harms” for the purposes of this guidance.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.A.3]]
+
+
+## Detect Cybersecurity Events in a Timely Fashion
+
+*Implement design features that allow for security compromises to be detected, recognized, logged, timed, and acted upon during normal use.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.B.1.a]]
+
+
+*Devices should be designed to permit routine security and antivirus scanning such that the safety and essential performance of the device is not impacted.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.B.1.b]]
+
+
+*Ensure the design enables forensic evidence capture. The design should include mechanisms to create and store log files for security events. Documentation should include how and where the log file is located, stored, recycled, archived, and how it could be consumed by automated analysis software (e.g. Intrusion Detection System, IDS). Examples of security events include but are not limited to configuration changes, network anomalies, login attempts, and anomalous traffic (e.g., sending requests to unknown entities).*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.B.1.c]]
+
+
+*The device design should limit the potential impact of vulnerabilities by specifying a secure configuration. Secure configurations may include endpoint protections such as anti-malware, firewall/firewall rules, whitelisting, defining security event parameters, logging parameters, physical security detection.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.B.1.d]]
+
+
+*The device design should enable software configuration management and permit tracking and control of software changes to be electronically obtainable (i.e., machine readable) by authorized users.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.B.1.e]]
+
+
+*The product life-cycle, including its design, should facilitate a variant analysis of a vulnerability across device models and product lines.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.B.1.f]]
+
+
+*The device design should provide a CBOM in a machine readable, electronic format to be consumed automatically.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.B.1.g]]
+
+
+## Respond to and Contain the Impact of a Potential Cybersecurity Incident
+
+*The device should be designed to notify users upon detection of a potential cybersecurity breach.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.B.2.a]]
+
+
+*The device should be designed to anticipate the need for software patches and updates to address future cybersecurity vulnerabilities.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.B.2.b]]
+
+
+*The device should be designed to facilitate the rapid verification, validation, and testing of patches and updates.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.B.2.c]]
+
+
+*The design architecture should facilitate the rapid deployment of patches and updates.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.B.2.d]]
+
+
+## Design the Device to Recover Capabilities or Services that were Impaired Due to a Cybersecurity Incident
+
+*Implement device features that protect critical functionality and data, even when the device’s cybersecurity has been compromised.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.B.3.b]]
+
+
+*The design should provide methods for retention and recovery of device configuration by an authenticated privileged user.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.B.3.c]]
+
+
+*The design should specify the level of autonomous functionality (resilience) any component of the system possesses when its communication capabilities with the rest of the system are disrupted including disruption of significant duration.*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.B.3.d]]
+
+
+*Devices should be designed to be resilient to possible cybersecurity incident scenarios such as network outages, Denial of Service attacks, excessive bandwidth usage by other products, disrupted quality of service (QoS), and excessive jitter (i.e., a variation in the delay of received packets).*
+
+TODO: demonstrate how this is implemented, e.g., by printing out the associated software requirements. If Tier 2, provide a risk-based rationale for why this specific design control isn't appropriate.
+
+[[FDA-CYBER:V.B.3.e]]
+
+## Additional Controls
+
+TODO: List additional cybersecurity controls here
+
+
+# Risk Management
+
+## System Level Threat Model
+
+TODO: Create a system level threat model that includes a consideration of system level risks, including but not limited to risks related to the supply chain (e.g., to ensure the device remains free of malware), design, production, and deployment (i.e., into a connected/networked environment). Its possible this could be combined with the systems diagrams.
+
+[[FDA-CYBER:7.B.1]]
+
+## Cybersecurity Risk Assessment
+
+TODO: List out all cybersecurity risks. The tables shown here should probably be produced by filtering out data from `risk.yml` somehow. Ideally, the software engineers would be able to use the same process for safety and security risks. Note that TIR57 suggests keeping these processes separate, in part because the cybersecurity risk analysis doesn't require the full multi-domain risk team. That said, we already split the full risk management process from the software-specific risk process, thus splitting it again doesn't make sense. That said, there should probably be one cybersecurity expert on the software team. Perhaps this person should be added to the CODEOWNERS file for parts of the system that involve cybersecurity.


### PR DESCRIPTION
Note that the document is not complete. In particular, it doesn't
include labeling requirements (we should add a user manual to our init
files) and it doesn't include some of the cybersecurity risk management
stuff.

Other items that should be done sooner or later:

- Incorporate cybersecurity risk management stuff into our software risk
  management processes.
- Add a checklist for MDCG 2019-16 - Guidance on Cybersecurity for
  medical devices, and figure out how to organize our documents to meet
  the E.U. and FDA stuff simultaneously, if possible.