### PR TITLE
Alter Issue Number Extraction RegEx from Branch Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,13 @@ RDM is especially well-suited for early-stage software-only medical devices that
 
 ## Quick Start
 
-```
+```sh
 pip install rdm[github]
+
+# Optional: Install git hooks
+rdm hooks
+
+# Scaffold initial template files and run
 rdm init
 cd regulatory
 make
@@ -71,6 +76,7 @@ The best companies follow the regulations with a degree of faith that these regu
 RDM is designed to be used within a typical software development workflow.  When a new project is started, developers
 
 1. Install RDM using `pip install rdm`
+    A) Optional: Install [RDM's git hooks](#git-hooks) using `rdm hooks` 
 2. Generate a set of markdown templates, which are stored in the git repository, using `rdm init`
 3. Edit configuration variables in the generated files
 4. Write _software requirements_ and store them in the git repository
@@ -318,6 +324,16 @@ You can list the builtin checklists with `rdm gap --list`.
 To provide a custom checklist, use a file path for the first argument.
 
 The checklist format is described in detail [here](./docs/checklist-format.md).
+
+## Git Hooks
+
+The `rdm hooks` command installs git hooks that will automatically add change request numbers to your git commit messages, based on your branch name.
+
+> When using this feature, name your branches in the style of `${hyphen-separated-issue-numbers}-rest-of-branch-name`.
+>
+> Example: `12-13-fixing-issues`
+
+If you manually edit one of the provided hooks and want to revert your changes or RDM has been updated and you want to make sure the newest hooks are used, you can re-run this command at any time.
 
 ## Contrib
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ The `rdm render` subcommand provides a few extra filters to the Jinja context:
 
 ### Extensions
 
-We also support [extensions](http://jinja.pocoo.org/docs/2.10/extensions/). Extensions are set using the `md_extensions` configuration paramater in `config.yml`. See the Markdown Extensions section for details about available markdown extensions.
+We also support [extensions](http://jinja.pocoo.org/docs/2.10/extensions/). Extensions are set using the `md_extensions` configuration parameter in `config.yml`. See the Markdown Extensions section for details about available markdown extensions.
 
 ## YAML Front Matter
 

--- a/README.md
+++ b/README.md
@@ -335,6 +335,8 @@ The `rdm hooks` command installs git hooks that will automatically add issue (or
 >
 > Example: `12-13-fixing-issues`
 
+Grabbing the issue number from the branch name works well since most of the time a branch will involve working on a particular issue. You can always edit the auto-generated messages on a per-commit basis if needed.
+
 If you manually edit one of the provided hooks and want to revert your changes or RDM has been updated and you want to make sure the newest hooks are used, you can re-run this command at any time.
 
 ## Contrib

--- a/README.md
+++ b/README.md
@@ -327,7 +327,9 @@ The checklist format is described in detail [here](./docs/checklist-format.md).
 
 ## Git Hooks
 
-The `rdm hooks` command installs git hooks that will automatically add change request numbers to your git commit messages, based on your branch name.
+Most git hosting platforms, e.g., GitHub, GitLab, and Bitbucket, allow you to trace git commits back to their originating issues using specially formatted comments. For example, if a commit is related to issue #123 you might include the text "Issue #123" in the git commit message. Maintaining this traceability helps RDM auto generate certain regulatory documents, but these links to every commit becomes tedious.
+
+The `rdm hooks` command installs git hooks that will automatically add issue (or, in regulatory speak, "change request") numbers to your git commit messages, based on your branch name.
 
 > When using this feature, name your branches in the style of `${hyphen-separated-issue-numbers}-rest-of-branch-name`.
 >

--- a/rdm/hook_files/prepare-commit-msg
+++ b/rdm/hook_files/prepare-commit-msg
@@ -5,7 +5,7 @@
 #
 append_feature_number_to_commit_message() {
     BRANCH=$(git branch | grep '*' | sed 's/* //')
-    ISSUES=$(echo "$BRANCH" | grep -o -E '[0-9]+')
+    ISSUES=$(echo "$BRANCH" | grep -o -E '^[0-9,-]+' | grep -o -E '[0-9]+')
     for ISSUE_NUMBER in ${ISSUES[@]}
     do
         echo -e "$(cat "$1")\n\nIssue #$ISSUE_NUMBER" > "$1"

--- a/tests/hook_test.py
+++ b/tests/hook_test.py
@@ -80,10 +80,10 @@ def test_multiple_issues(tmp_repo):
     assert show_commit_message() == "Fix some issue\n\nIssue #10\n\nIssue #11\n\n"
 
 
-def test_text_before_issue(tmp_repo):
-    prepare_branch(tmp_repo, 'fix-10-sample-issue')
+def test_mixed_non_issue_numbers(tmp_repo):
+    prepare_branch(tmp_repo, '42-85-implement-base-64-on-aws-s3')
     tmp_repo.git.commit('-m', 'Fix some issue')
-    assert show_commit_message() == "Fix some issue\n\nIssue #10\n\n"
+    assert show_commit_message() == "Fix some issue\n\nIssue #42\n\nIssue #85\n\n"
 
 
 def test_no_issue_number(tmp_repo):


### PR DESCRIPTION
Closes #103

In addition to altering the issue number RegEx and adding notes to the README on `rdm hooks`, I also threw in a quick typo fix and adding a language specifier to the MD code fence block in `Quick Install`.